### PR TITLE
Fixed carousel slider

### DIFF
--- a/videos.html
+++ b/videos.html
@@ -1,4 +1,5 @@
-<!DOCTYPE html>
+<!-- <!DOCTYPE html> -->
+<!-- DOCTYPE is incompatible with carousel slider -->
 <html>
 	<head>
 		<title>Daniel Kenafake - Videos</title>


### PR DESCRIPTION
The HTML 5 DOCTYPE is not compatible with the Owl carousel slider.
